### PR TITLE
Add NekoRay and Happ clients to documentation

### DIFF
--- a/docs/Client Side/Clients.en.md
+++ b/docs/Client Side/Clients.en.md
@@ -1,7 +1,9 @@
 # Clients
 
+- ⭐ [NekoRay](https://en.nekoray.org/download/) - Windows / Linux
 - ⭐ [v2rayN](https://github.com/2dust/v2rayN) - Windows / Mac / Linux
 - ⭐ [NekoBox For Android](https://github.com/MatsuriDayo/NekoBoxForAndroid) - Android
 - ⭐ [sing-box](https://github.com/SagerNet/sing-box) - Windows / Mac / Linux / Android / IOS / [GUI](https://sing-box.sagernet.org/clients/) / [Config](https://4n0nymou3.github.io/proxy-to-singbox-converter/)
+- [Happ](https://www.happ.su/main) - Windows / Mac / Linux
 - [Hiddify](https://hiddify.com/) - Windows / Mac / Linux / Android / IOS
 - [v2rayNG](https://github.com/2dust/v2rayNG) - Android


### PR DESCRIPTION
It's the one that works for me. You can change its place in the list of clients by how much you think it's useful.